### PR TITLE
Fix: Fixed editing name in Profile.js

### DIFF
--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -14,6 +14,9 @@ class Profile extends Component {
             error: null,
             submitted: false
         }
+
+         // this.onChange = this.onChange.bind(this);
+
     }
 
     componentDidMount() {
@@ -71,7 +74,7 @@ class Profile extends Component {
                         <Form>
                             <Form.Input
                                 name="name"
-                                value={this.state.name ? this.state.name : userinfo.name}
+                                value={this.state.name}
                                 onChange={this.onChange}
                                 label='Name'
                                 placeholder='Enter your name...' 
@@ -107,7 +110,7 @@ class Profile extends Component {
                     <Form>
                         <Form.Input
                             name="name"
-                            value={this.state.name}
+                            value={this.state.name }
                             onChange={this.onChange}
                             label='Name'
                             placeholder='Enter your username...' 
@@ -142,10 +145,11 @@ Profile.propTypes = {
     patchInfo: PropTypes.func.isRequired
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state, ownProps) => ({
     userinfo: state.info.userinfo,
     userinfoerror: state.info.userinfoerror,
     userinfoid: state.info.userinfoid,
+
 })
 
 export default connect(

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -15,8 +15,6 @@ class Profile extends Component {
             submitted: false
         }
 
-         // this.onChange = this.onChange.bind(this);
-
     }
 
     componentDidMount() {
@@ -145,7 +143,7 @@ Profile.propTypes = {
     patchInfo: PropTypes.func.isRequired
 };
 
-const mapStateToProps = (state, ownProps) => ({
+const mapStateToProps = (state) => ({
     userinfo: state.info.userinfo,
     userinfoerror: state.info.userinfoerror,
     userinfoid: state.info.userinfoid,

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -14,7 +14,6 @@ class Profile extends Component {
             error: null,
             submitted: false
         }
-
     }
 
     componentDidMount() {
@@ -72,7 +71,7 @@ class Profile extends Component {
                         <Form>
                             <Form.Input
                                 name="name"
-                                value={this.state.name}
+                                defaultValue={userinfo.name}
                                 onChange={this.onChange}
                                 label='Name'
                                 placeholder='Enter your name...' 
@@ -147,7 +146,6 @@ const mapStateToProps = (state) => ({
     userinfo: state.info.userinfo,
     userinfoerror: state.info.userinfoerror,
     userinfoid: state.info.userinfoid,
-
 })
 
 export default connect(

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -71,7 +71,7 @@ class Profile extends Component {
                         <Form>
                             <Form.Input
                                 name="name"
-                                defaultValue={userinfo.name}
+                                defaultValue={this.state.name ? this.state.name : userinfo.name}
                                 onChange={this.onChange}
                                 label='Name'
                                 placeholder='Enter your name...' 
@@ -107,7 +107,7 @@ class Profile extends Component {
                     <Form>
                         <Form.Input
                             name="name"
-                            value={this.state.name }
+                            value={this.state.name}
                             onChange={this.onChange}
                             label='Name'
                             placeholder='Enter your username...' 
@@ -142,7 +142,7 @@ Profile.propTypes = {
     patchInfo: PropTypes.func.isRequired
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
     userinfo: state.info.userinfo,
     userinfoerror: state.info.userinfoerror,
     userinfoid: state.info.userinfoid,


### PR DESCRIPTION
### Description
Currently, the edit profile functionality is not working as expected. The first character does not get deleted on backspace. This has to be modified accordingly in the frontend part so that the user an easily update the username.

Fixes #44 

### Type of Change:

- Code


**Code/Quality Assurance Only**
- Bugfix (non-breaking change which fixes an issue)


### How Has This Been Tested?
I've tested it locally, the updated name is also reflected in Django backend.


### Checklist:

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules