### PR TITLE
Spelling mistake and comma missing in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ npm start
 Please read the Contibuting guidelines, [Code of Conduct](https://github.com/anitab-org/open-source-programs-web/blob/develop/CODE_OF_CONDUCT.md) and [Reporting Guidelines](https://github.com/anitab-org/open-source-programs-web/blob/develop/REPORTING_GUIDELINES.md)
 
 ## Contact
-You can reach the admins, maintainers and our community on [AnitaB.org Open Source Zulip](https://anitab-org.zulipchat.com/). If you are interested in contributing to the OSP project, you may join the stream [#open-source-progs](https://anitab-org.zulipchat.com/#narrow/stream/237907-open-source-progs) and ask questions or intereact with the community. Join Us!
+You can reach the admins, maintainers, and our community on [AnitaB.org Open Source Zulip](https://anitab-org.zulipchat.com/). If you are interested in contributing to the OSP project, you may join the stream [#open-source-progs](https://anitab-org.zulipchat.com/#narrow/stream/237907-open-source-progs) and ask questions or interact with the community. Join Us!


### PR DESCRIPTION
Fixes #56 
I noticed that there is a spelling mistake in word interact and a comma missing after the word maintainers, hence corrected that.

### Description

<!--Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change.-->
Before
![image](https://user-images.githubusercontent.com/66299533/91538451-7e510980-e935-11ea-90ba-be4872df6b22.png)
After
![image](https://user-images.githubusercontent.com/66299533/91538519-9163d980-e935-11ea-8b18-38af85a58bbd.png)


### Type of Change:
<!--**Delete irrelevant options.**-->


- Documentation




