### PR TITLE
Tests: Add tests for checking validations on Register form

### DIFF
--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -195,6 +195,7 @@ class Register extends Component {
                   icon={
                     <Icon
                       name={showPassword ? 'eye slash outline' : 'eye'}
+                      data-testid="hide-display-password"
                       onClick={this.handleShow}
                       link
                     />
@@ -212,6 +213,7 @@ class Register extends Component {
                   icon={
                     <Icon
                       name={showConfirmPassword ? 'eye slash outline' : 'eye'}
+                      data-testid="hide-display-confirm-password"
                       onClick={this.handleShowConfirm}
                       link
                     />

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -179,6 +179,7 @@ class Register extends Component {
                   label="Username"
                   required
                   placeholder="Enter your username..."
+                  data-testid="username"
                 />
                 <Form.Input
                   name="email"
@@ -187,6 +188,7 @@ class Register extends Component {
                   label="Email"
                   required
                   placeholder="Enter your email..."
+                  data-testid="email"
                 />
                 <Form.Input
                   type={showPassword ? 'text' : 'password'}
@@ -203,6 +205,7 @@ class Register extends Component {
                   label="Password"
                   required
                   placeholder="Enter your password..."
+                  data-testid="password"
                 />
                 <Form.Input
                   type={showConfirmPassword ? 'text' : 'password'}
@@ -219,6 +222,7 @@ class Register extends Component {
                   label="Confirm Password"
                   required
                   placeholder="Confirm your password..."
+                  data-testid="confirm_password"
                 />
                 <Form.Button
                   fluid
@@ -230,6 +234,7 @@ class Register extends Component {
                     !this.state.password ||
                     !this.state.confirm_password
                   }
+                  data-testid="register_btn"
                 >
                   REGISTER
                 </Form.Button>

--- a/src/tests/Register.test.js
+++ b/src/tests/Register.test.js
@@ -1,5 +1,9 @@
 import { screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import axios from 'axios';
+import { postRegister } from '../actions/login';
+
+jest.mock('axios');
 
 import Register from '../components/Register';
 import { renderWithReduxAndRouter } from './baseRenderers';
@@ -199,5 +203,55 @@ describe('Register Button:', () => {
     });
 
     expect(registerBtn).toBeDisabled();
+  });
+});
+
+describe('Password Eye Icon:', () => {
+  it('Clicking password eye icon of the password input should display the password text', () => {
+    renderWithReduxAndRouter(Register, {
+      route,
+    });
+    const passwordInput = screen.getByTestId('password').querySelector('input');
+    const passwordDisplayHideIcon = screen.getByTestId('hide-display-password');
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    fireEvent.click(passwordDisplayHideIcon);
+    expect(passwordInput).toHaveAttribute('type', 'text');
+  });
+
+  it('Clicking password eye icon of the confirm password input should display the password text', () => {
+    renderWithReduxAndRouter(Register, {
+      route,
+    });
+    const passwordInput = screen
+      .getByTestId('confirm_password')
+      .querySelector('input');
+    const passwordDisplayHideIcon = screen.getByTestId(
+      'hide-display-confirm-password'
+    );
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    fireEvent.click(passwordDisplayHideIcon);
+    expect(passwordInput).toHaveAttribute('type', 'text');
+  });
+});
+
+describe('Successful Registration', () => {
+  it('Should see success message', async () => {
+    axios.post.mockImplementationOnce(() =>
+      Promise.resolve({
+        data: { data: ['Your email is confirmed!'] },
+        status: 200,
+      })
+    );
+
+    const callback = jest.fn(() => Promise.resolve(true));
+    const registration = {
+      username: 'username123',
+      email: 'test@gmail.com',
+      password: 'Testpassword123!',
+      confirm_password: 'Testpassword123!',
+    };
+
+    const result = postRegister((registration, callback));
+    console.log(result);
   });
 });

--- a/src/tests/Register.test.js
+++ b/src/tests/Register.test.js
@@ -235,23 +235,26 @@ describe('Password Eye Icon:', () => {
 });
 
 describe('Successful Registration', () => {
-  it('Should see success message', async () => {
-    axios.post.mockImplementationOnce(() =>
-      Promise.resolve({
-        data: { data: ['Your email is confirmed!'] },
-        status: 200,
-      })
-    );
-
-    const callback = jest.fn(() => Promise.resolve(true));
+  it('Should see register action dispatched upon successful registration', async () => {
+    const response = {
+      data: { detail: 'Please confirm your email to Login succesfully' },
+      status: 200,
+    };
+    axios.post.mockImplementationOnce(() => Promise.resolve(response));
+    const callback = jest.fn();
+    const dispatchMock = jest.fn();
     const registration = {
       username: 'username123',
       email: 'test@gmail.com',
       password: 'Testpassword123!',
       confirm_password: 'Testpassword123!',
     };
-
-    const result = postRegister((registration, callback));
-    console.log(result);
+    const dispatch = postRegister(registration, callback);
+    await dispatch(dispatchMock);
+    expect(callback).toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledWith({
+      payload: response.data,
+      type: 'REGISTER',
+    });
   });
 });

--- a/src/tests/Register.test.js
+++ b/src/tests/Register.test.js
@@ -1,0 +1,203 @@
+import { screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Register from '../components/Register';
+import { renderWithReduxAndRouter } from './baseRenderers';
+
+const route = '/register';
+
+describe('Validation Message UI:', () => {
+  it('Validation check pops up if the email is not in correct format', () => {
+    renderWithReduxAndRouter(Register, {
+      route,
+    });
+    const usernameInput = screen.getByTestId('username').querySelector('input');
+    const emailInput = screen.getByTestId('email').querySelector('input');
+    const passwordInput = screen.getByTestId('password').querySelector('input');
+    const confirmPasswordInput = screen
+      .getByTestId('confirm_password')
+      .querySelector('input');
+    const registerBtn = screen.getByTestId('register_btn');
+    fireEvent.change(usernameInput, {
+      target: { value: 'username123' },
+    });
+
+    fireEvent.change(emailInput, {
+      target: { value: 'testinvalid.com' },
+    });
+
+    fireEvent.change(passwordInput, {
+      target: { value: 'Testpassword123!' },
+    });
+
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: 'Testpassword123!' },
+    });
+
+    fireEvent.click(registerBtn);
+    expect(screen.getByText('Email format is not valid!')).toBeInTheDocument();
+  });
+
+  it('Validation check pops up if passwords are not same', () => {
+    renderWithReduxAndRouter(Register, {
+      route,
+    });
+    const usernameInput = screen.getByTestId('username').querySelector('input');
+    const emailInput = screen.getByTestId('email').querySelector('input');
+    const passwordInput = screen.getByTestId('password').querySelector('input');
+    const confirmPasswordInput = screen
+      .getByTestId('confirm_password')
+      .querySelector('input');
+    const registerBtn = screen.getByTestId('register_btn');
+
+    fireEvent.change(usernameInput, {
+      target: { value: 'username123' },
+    });
+
+    fireEvent.change(emailInput, {
+      target: { value: 'test@gmail.com' },
+    });
+
+    fireEvent.change(passwordInput, {
+      target: { value: 'Testpassword123!' },
+    });
+
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: 'TestPassword123!' },
+    });
+
+    fireEvent.click(registerBtn);
+    expect(screen.getByText('Passwords do not match!')).toBeInTheDocument();
+  });
+
+  it('Validation check pops up if the password is not in correct format', () => {
+    renderWithReduxAndRouter(Register, {
+      route,
+    });
+    const usernameInput = screen.getByTestId('username').querySelector('input');
+    const emailInput = screen.getByTestId('email').querySelector('input');
+    const passwordInput = screen.getByTestId('password').querySelector('input');
+    const confirmPasswordInput = screen
+      .getByTestId('confirm_password')
+      .querySelector('input');
+    const registerBtn = screen.getByTestId('register_btn');
+
+    fireEvent.change(usernameInput, {
+      target: { value: 'username123' },
+    });
+
+    fireEvent.change(emailInput, {
+      target: { value: 'test@gmail.com' },
+    });
+
+    fireEvent.change(passwordInput, {
+      target: { value: 'testpassword123!' },
+    });
+
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: 'testpassword123!' },
+    });
+
+    fireEvent.click(registerBtn);
+    expect(
+      screen.getByText(
+        'Password is too short and not valid! It should contain minimum 12 characters, at least one uppercase letter, one lowercase letter, one number and one special character.'
+      )
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Register Button:', () => {
+  it('Should be enabled if all fields are filled', () => {
+    renderWithReduxAndRouter(Register, {
+      route,
+    });
+    const usernameInput = screen.getByTestId('username').querySelector('input');
+    const emailInput = screen.getByTestId('email').querySelector('input');
+    const passwordInput = screen.getByTestId('password').querySelector('input');
+    const confirmPasswordInput = screen
+      .getByTestId('confirm_password')
+      .querySelector('input');
+    const registerBtn = screen.getByTestId('register_btn');
+
+    fireEvent.change(usernameInput, {
+      target: { value: 'username123' },
+    });
+
+    fireEvent.change(emailInput, {
+      target: { value: 'test@gmail.com' },
+    });
+
+    fireEvent.change(passwordInput, {
+      target: { value: 'Testpassword123!' },
+    });
+
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: 'Testpassword123!' },
+    });
+
+    expect(registerBtn).toBeEnabled();
+  });
+
+  it('Should be disabled if username field is empty', () => {
+    renderWithReduxAndRouter(Register, {
+      route,
+    });
+    const usernameInput = screen.getByTestId('username').querySelector('input');
+    const emailInput = screen.getByTestId('email').querySelector('input');
+    const passwordInput = screen.getByTestId('password').querySelector('input');
+    const confirmPasswordInput = screen
+      .getByTestId('confirm_password')
+      .querySelector('input');
+    const registerBtn = screen.getByTestId('register_btn');
+
+    fireEvent.change(usernameInput, {
+      target: { value: '' },
+    });
+
+    fireEvent.change(emailInput, {
+      target: { value: 'test@gmail.com' },
+    });
+
+    fireEvent.change(passwordInput, {
+      target: { value: 'Testpassword123!' },
+    });
+
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: 'Testpassword123!' },
+    });
+
+    expect(registerBtn).toBeDisabled();
+  });
+
+  it('Register button should be disabled if the email field is empty', () => {
+    renderWithReduxAndRouter(Register, {
+      route,
+    });
+    const usernameInput = screen.getByTestId('username').querySelector('input');
+    const emailInput = screen.getByTestId('email').querySelector('input');
+    const passwordInput = screen.getByTestId('password').querySelector('input');
+    const confirmPasswordInput = screen
+      .getByTestId('confirm_password')
+      .querySelector('input');
+    const registerBtn = screen.getByTestId('register_btn');
+
+    fireEvent.change(usernameInput, {
+      target: { value: 'username123' },
+    });
+
+    fireEvent.change(emailInput, {
+      target: { value: '' },
+    });
+
+    fireEvent.change(passwordInput, {
+      target: { value: 'Testpassword123!' },
+    });
+
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: 'Testpassword123!' },
+    });
+
+    expect(registerBtn).toBeDisabled();
+  });
+});


### PR DESCRIPTION
### Description

Add tests to check input validations and button ui on Register form

Fixes #173 
- Note: if the email or username field is empty, the button is disabled so no validation UI can be provided if the user cannot press the Register button. I added 3 tests to show that the button is disabled if those fields are empty, as well as a test to show it's enabled when all fields are filled. 

### Type of Change:
- Code: Added `data-testid` to input and button components
- Quality Assurance: Added testing for Register Component


### How Has This Been Tested?
Run `npm test` on the CLI - all tests should pass

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes